### PR TITLE
Fix Graphcool Server support - Don't expect KA always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - fix shallow cloning on contexts which are classes
+- fix Graphcool server support - use data received connection_ack also as Keep alive
 
 ### 0.9.5
 - docs(setup): Fix dead link to subscriptions-to-schema

--- a/src/client.ts
+++ b/src/client.ts
@@ -575,6 +575,12 @@ export class SubscriptionClient {
         break;
 
       case MessageTypes.GQL_DATA:
+        //LX: If we received data we clear the counter
+        if (this.checkConnectionIntervalId) {
+          clearInterval(this.checkConnectionIntervalId);
+          this.checkConnection();
+        }
+        this.checkConnectionIntervalId = setInterval(this.checkConnection.bind(this), this.wsTimeout);
         const parsedPayload = !parsedMessage.payload.errors ?
           parsedMessage.payload : {...parsedMessage.payload, errors: this.formatErrors(parsedMessage.payload.errors)};
         this.operations[opId].handler(null, parsedPayload);


### PR DESCRIPTION
Currently, the client expects the type KA message to be received to clear the reconnection counter. With this fix, if we received DATA we also clear the counter

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x ] Rebase your changes on master so that they can be merged easily
- [x ] Make sure all tests and linter rules pass
- [ x] Update CHANGELOG.md with your change
